### PR TITLE
Mention `is-heroku-bin`

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -27,3 +27,7 @@ Add an [environment variable](https://devcenter.heroku.com/articles/config-vars)
 ```sh
 heroku config:set HEROKU=1
 ```
+
+## Related
+
+- [is-heroku-bin](https://github.com/shian15810/is-heroku-bin) - CLI for this module


### PR DESCRIPTION
I needed exactly this but the CLI version of it, mostly to use in tandem with `is-ci` and `husky install` like so:

```jsonc
// package.json
{
  "scripts": {
    "prepare": "is-ci || is-heroku || husky install"
  }
}
```

Since [`is-heroku-cli`](https://www.npmjs.com/package/is-heroku-cli) is occupied and has been deprecated, so I made the CLI version and published under [`is-heroku-bin`](https://github.com/shian15810/is-heroku-bin).

Perhaps others will find this useful as well.